### PR TITLE
load gltf scene using new syntax in load_gltf_extras.rs

### DIFF
--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -29,9 +29,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         ..default()
     });
+    
     // a barebones scene containing one of each gltf_extra type
     commands.spawn(SceneBundle {
-        scene: asset_server.load("models/extras/gltf_extras.glb#Scene0"),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb")),
         ..default()
     });
 

--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -29,10 +29,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         ..default()
     });
-    
+
     // a barebones scene containing one of each gltf_extra type
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb")),
         ..default()
     });
 


### PR DESCRIPTION
# Objective

update the `load_gltf_extras.rs` example to the newest bevy api

## Solution

uses the new type-safe code for loading the scene #0 from the gltf instead of a path suffix

## Testing

the example runs as expected

